### PR TITLE
SILSLA-18: Implements MARC manipulations from sections 3-5 of SILSLA-18 specs

### DIFF
--- a/scp_bib_update.py
+++ b/scp_bib_update.py
@@ -14,14 +14,14 @@ import sys
 from pymarc import MARCReader, MARCWriter
 
 def delete_590(record):
-	"""	Delete 590 field containing $a UCLA Library - CDL shared resource """
+	""" Delete 590 field containing $a UCLA Library - CDL shared resource """
 	for fld in record.get_fields('590'):
 		# Should be only one $a per 590 field
 		if fld['a'].startswith('UCLA Library - CDL shared resource'):
 			record.remove_field(fld)
 
 def delete_599(record):
-	"""	Delete 599 field where $a is UPD or DEL or NEW, and $c is present """
+	""" Delete 599 field where $a is UPD or DEL or NEW, and $c is present """
 	scp_vals = ['DEL', 'NEW', 'UPD']
 	for fld in record.get_fields('599'):
 		# Should be only one $a per 599 field
@@ -29,12 +29,12 @@ def delete_599(record):
 			record.remove_field(fld)			
 
 def delete_793(record):
-	"""	Delete 793 field regardless of content """
+	""" Delete 793 field regardless of content """
 	for fld in record.get_fields('793'):
 		record.remove_field(fld)
 
 def delete_856(record):
-	"""	Delete 856 field where $x is CDL or UC open access """
+	""" Delete 856 field where $x is CDL or UC open access """
 	scp_vals = ['CDL', 'UC open access']
 	for fld in record.get_fields('856'):
 		# 856 can have multiple $x
@@ -45,7 +45,7 @@ def delete_856(record):
 				break
 
 def modify_856(record):
-	"""	Modify 856 field where $x is CDL or UC open access,
+	""" Modify 856 field where $x is CDL or UC open access,
 		setting 856 $u dummyURL
 	"""
 	scp_vals = ['CDL', 'UC open access']

--- a/scp_bib_update.py
+++ b/scp_bib_update.py
@@ -1,0 +1,87 @@
+"""
+Implements MARC manipulations from sections 3-5 of SILSLA-18.
+The program:
+* Deletes relevant 590 field(s)
+* Deletes relevant 599 field(s)
+* Deletes all 793 fields
+* Deletes or modifies SCP 856 fields, based on has_po parameter
+Parameters:
+* in_file: input file of MARC records
+* out_file: output file of updated MARC records
+* has_po_(Y/N): Y/N flag, whether records have a linked PO.
+"""
+import sys
+from pymarc import MARCReader, MARCWriter
+
+def delete_590(record):
+	"""	Delete 590 field containing $a UCLA Library - CDL shared resource """
+	for fld in record.get_fields('590'):
+		# Should be only one $a per 590 field
+		if fld['a'].startswith('UCLA Library - CDL shared resource'):
+			record.remove_field(fld)
+
+def delete_599(record):
+	"""	Delete 599 field where $a is UPD or DEL or NEW, and $c is present """
+	scp_vals = ['DEL', 'NEW', 'UPD']
+	for fld in record.get_fields('599'):
+		# Should be only one $a per 599 field
+		if (fld['a'] in scp_vals) and (fld['c'] is not None):
+			record.remove_field(fld)			
+
+def delete_793(record):
+	"""	Delete 793 field regardless of content """
+	for fld in record.get_fields('793'):
+		record.remove_field(fld)
+
+def delete_856(record):
+	"""	Delete 856 field where $x is CDL or UC open access """
+	scp_vals = ['CDL', 'UC open access']
+	for fld in record.get_fields('856'):
+		# 856 can have multiple $x
+		for sfld in fld.get_subfields('x'):
+			if sfld in scp_vals:
+				record.remove_field(fld)
+				# If fld was deleted, break out of the sfld loop
+				break
+
+def modify_856(record):
+	"""	Modify 856 field where $x is CDL or UC open access,
+		setting 856 $u dummyURL
+	"""
+	scp_vals = ['CDL', 'UC open access']
+	for fld in record.get_fields('856'):
+		print(f'Checking {fld}')
+		# 856 can have multiple $x
+		for sfld in fld.get_subfields('x'):
+			if sfld in scp_vals:
+				# Should be only one $u per 856 field
+				fld['u'] = 'dummyURL'
+				# If fld was modified, break out of the sfld loop
+				break
+
+### Main code starts here ###
+if len(sys.argv) != 4:
+    raise ValueError(f'Usage: {sys.argv[0]} in_file out_file has_po_(Y/N)')
+reader = MARCReader(open(sys.argv[1], 'rb'))
+writer = MARCWriter(open(sys.argv[2], 'wb'))
+has_po = sys.argv[3]
+if has_po not in ['Y', 'N']:
+	raise ValueError(f'Invalid value {has_po}; must be Y or N')
+
+for record in reader:
+	delete_590(record)
+	delete_599(record)
+	delete_793(record)
+	if has_po == 'Y':
+		# Case 4 from specs
+		modify_856(record)
+	else:
+		# Cases 3 and 5 from sepcs
+		delete_856(record)
+
+	# Done making changes, save the changed record to file
+	writer.write(record)
+    	
+# Cleanup
+writer.close()
+reader.close()


### PR DESCRIPTION
This program implements the MARC updates from sections 3-5 of the SILSLA-18 specs.

It does not address sections 1-2 (deletion / suppression of records), or section 5.e (holdings deletion).  Those will be handled by different processes, separately from these MARC updates.

@aprigge Please review, comparing with the [specs](https://jira.library.ucla.edu/browse/SILSLA-18) to confirm this implements everything correctly.  I've tested locally with some sample records and all seems correct, but we need to be sure I implemented what the specs say and not what I think they say :)

Questions and suggestions are welcome, if anything is unclear or could be improved.

If all is OK, please squash and merge.  Thanks --Andy