### PR TITLE
SILSLA-18: Queries to find bib ids for all cases

### DIFF
--- a/SQL/scp_silsla18_case1.sql
+++ b/SQL/scp_silsla18_case1.sql
@@ -1,0 +1,38 @@
+-- Spec #1: Pure CDL bibs, no print holdings, no UCLA 856 fields, WITHOUT PO
+-- DELETE bibs and holdings for Vanguard.
+with bibs as (
+  select distinct
+    record_id as bib_id
+  from vger_subfields.ucladb_bib_subfield bs
+  where tag = '856x'
+  -- Significant (3700+) typos and case variations
+  and (subfield like 'CDL%' or upper(subfield) like 'UC OPEN ACCESS%')
+  and not exists (
+    select *
+    from vger_subfields.ucladb_bib_subfield
+    where record_id = bs.record_id
+    and tag = '856x'
+    and subfield in ('UCLA', 'UCLA Law')
+  )
+)
+, print as (
+  select b.bib_id
+  from bibs b
+  inner join bib_mfhd bm on b.bib_id = bm.bib_id
+  inner join mfhd_master mm on bm.mfhd_id = mm.mfhd_id
+  inner join location l on mm.location_id = l.location_id
+  where l.location_code != 'in'
+)
+, online_only as (
+  select bib_id from bibs
+  minus
+  select bib_id from print
+)
+select bib_id
+from online_only o
+where not exists (
+  select * from line_item
+  where bib_id = o.bib_id
+)
+order by bib_id
+;

--- a/SQL/scp_silsla18_case2.sql
+++ b/SQL/scp_silsla18_case2.sql
@@ -1,0 +1,38 @@
+-- Spec #2: Pure CDL bibs, no print holdings, no UCLA 856 fields, WITH PO
+-- DELETE bibs and holdings for Vanguard.
+with bibs as (
+  select distinct
+    record_id as bib_id
+  from vger_subfields.ucladb_bib_subfield bs
+  where tag = '856x'
+  -- Significant (3700+) typos and case variations
+  and (subfield like 'CDL%' or upper(subfield) like 'UC OPEN ACCESS%')
+  and not exists (
+    select *
+    from vger_subfields.ucladb_bib_subfield
+    where record_id = bs.record_id
+    and tag = '856x'
+    and subfield in ('UCLA', 'UCLA Law')
+  )
+)
+, print as (
+  select b.bib_id
+  from bibs b
+  inner join bib_mfhd bm on b.bib_id = bm.bib_id
+  inner join mfhd_master mm on bm.mfhd_id = mm.mfhd_id
+  inner join location l on mm.location_id = l.location_id
+  where l.location_code != 'in'
+)
+, online_only as (
+  select bib_id from bibs
+  minus
+  select bib_id from print
+)
+select bib_id
+from online_only o
+where exists (
+  select * from line_item
+  where bib_id = o.bib_id
+)
+order by bib_id
+;

--- a/SQL/scp_silsla18_case3.sql
+++ b/SQL/scp_silsla18_case3.sql
@@ -1,0 +1,43 @@
+-- Spec #3: Hybrid CDL/UCLA bibs WITHOUT open CDL PO
+-- UPDATE bibs, with CDL 856 deletion
+with bibs as (
+  select distinct
+    record_id as bib_id
+  from vger_subfields.ucladb_bib_subfield bs
+  where tag = '856x'
+  -- Significant (3700+) typos and case variations
+  and (subfield like 'CDL%' or upper(subfield) like 'UC OPEN ACCESS%')
+  and exists (
+    select *
+    from vger_subfields.ucladb_bib_subfield
+    where record_id = bs.record_id
+    and tag = '856x'
+    and subfield in ('UCLA', 'UCLA Law')
+  )
+), cdl_open_orders as (
+  select
+    b.bib_id
+  , po.po_number
+  , v.vendor_code
+  , pos.po_status_desc
+  from bibs b
+  inner join bib_mfhd bm on b.bib_id = bm.bib_id
+  inner join mfhd_master mm on bm.mfhd_id = mm.mfhd_id
+  inner join location l on mm.location_id = l.location_id
+  inner join line_item_copy_status lics on mm.mfhd_id = lics.mfhd_id
+  inner join line_item li on lics.line_item_id = li.line_item_id
+  inner join purchase_order po on li.po_id = po.po_id
+  inner join vendor v on po.vendor_id = v.vendor_id
+  inner join po_status pos on po.po_status = pos.po_status
+  where l.location_code = 'in'
+  and v.vendor_code = 'LXO'
+  and pos.po_status_desc in ('Approved/Sent', 'Received Partial')
+)
+select bib_id
+from bibs b
+where not exists (
+  select * from cdl_open_orders
+  where bib_id = b.bib_id
+)
+order by bib_id
+;

--- a/SQL/scp_silsla18_case4.sql
+++ b/SQL/scp_silsla18_case4.sql
@@ -1,0 +1,43 @@
+-- Spec #4: Hybrid CDL/UCLA bibs WITH open CDL PO
+-- UPDATE bibs, with CDL 856 modification
+with bibs as (
+  select distinct
+    record_id as bib_id
+  from vger_subfields.ucladb_bib_subfield bs
+  where tag = '856x'
+  -- Significant (3700+) typos and case variations
+  and (subfield like 'CDL%' or upper(subfield) like 'UC OPEN ACCESS%')
+  and exists (
+    select *
+    from vger_subfields.ucladb_bib_subfield
+    where record_id = bs.record_id
+    and tag = '856x'
+    and subfield in ('UCLA', 'UCLA Law')
+  )
+), cdl_open_orders as (
+  select
+    b.bib_id
+  , po.po_number
+  , v.vendor_code
+  , pos.po_status_desc
+  from bibs b
+  inner join bib_mfhd bm on b.bib_id = bm.bib_id
+  inner join mfhd_master mm on bm.mfhd_id = mm.mfhd_id
+  inner join location l on mm.location_id = l.location_id
+  inner join line_item_copy_status lics on mm.mfhd_id = lics.mfhd_id
+  inner join line_item li on lics.line_item_id = li.line_item_id
+  inner join purchase_order po on li.po_id = po.po_id
+  inner join vendor v on po.vendor_id = v.vendor_id
+  inner join po_status pos on po.po_status = pos.po_status
+  where l.location_code = 'in'
+  and v.vendor_code = 'LXO'
+  and pos.po_status_desc in ('Approved/Sent', 'Received Partial')
+)
+select bib_id
+from bibs b
+where exists (
+  select * from cdl_open_orders
+  where bib_id = b.bib_id
+)
+order by bib_id
+;

--- a/SQL/scp_silsla18_case5.sql
+++ b/SQL/scp_silsla18_case5.sql
@@ -1,0 +1,30 @@
+-- Spec #5: Pure CDL bibs, HAS print holdings, no UCLA 856 fields
+-- UPDATE bibs, with CDL 856 deletion, AND delete internet holdings
+with bibs as (
+  select distinct
+    record_id as bib_id
+  from vger_subfields.ucladb_bib_subfield bs
+  where tag = '856x'
+  -- Significant (3700+) typos and case variations
+  and (subfield like 'CDL%' or upper(subfield) like 'UC OPEN ACCESS%')
+  and not exists (
+    select *
+    from vger_subfields.ucladb_bib_subfield
+    where record_id = bs.record_id
+    and tag = '856x'
+    and subfield in ('UCLA', 'UCLA Law')
+  )
+)
+, has_print as (
+  select distinct b.bib_id
+  from bibs b
+  inner join bib_mfhd bm on b.bib_id = bm.bib_id
+  inner join mfhd_master mm on bm.mfhd_id = mm.mfhd_id
+  inner join location l on mm.location_id = l.location_id
+  where l.location_code != 'in'
+)
+-- TODO: Possibly augment this with internet holdings ids for deletion
+select bib_id
+from has_print p
+order by bib_id
+;


### PR DESCRIPTION
This PR adds 5 queries, one for each case in the SILSLA-18 specs.  A shell script (to be written) will call each of these to obtain the bib records needed, then pass those files and other relevant info to the `scp_bib_update.py` program for updating, then load the updated records back into Voyager.

Each of these queries acts on a base set of records: bibs with 856 $x starting with `CDL` or `UC Open Access` (case-insensitive).  The queries each focus on a different subset of that base.  As a whole, every record in the base should be included in one and only one subset.

As of today, the base set contains 1,285,012 bib records.  I've confirmed:
* Set 1: 1,265,595 bibs
* Set 2: 261 bibs
* Set 3: 14,168 bibs
* Set 4: 15 bibs
* Set 5: 4,973 bibs
Total: 1,285,012 bibs 
