### PR TITLE
SILSLA-20: Add main controller script

### DIFF
--- a/process_vanguard_bibs.py
+++ b/process_vanguard_bibs.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import copy
 from pymarc import Record, Field, MARCReader, MARCWriter
@@ -65,8 +66,9 @@ def delete_various_9xx(record):
 
 def get_dbcode(filename):
     """Helper function to get dbcode from filename"""
+	basename = os.path.basename(filename)
     for dbcode in ["filmntvdb", "ucladb", "ethnodb"]:
-        if filename.startswith(dbcode):
+        if basename.startswith(dbcode):
             return dbcode
         else:
             raise ValueError(

--- a/sils_update_bibs.sh
+++ b/sils_update_bibs.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+# Extracts bib records from all 3 Voyager databases,
+# calls appropriate cleanup programs for each file,
+# and loads updated records back into the relevant database.
+# SILSLA-20
+
+##########################################################################
+# Get max record id of a type for a database
+_get_max_id() {
+  DB=$1
+  TYPE=$2
+  SCHEMA=ucla_preaddb
+  PASSWORD=ucla_preaddb
+  SQLFILE=max_${DB}_${TYPE}.sql
+  echo "select 'MAXID=', max(${TYPE}_id) from ${DB}.${TYPE}_master;" > ${SQLFILE}
+  MAXID=`sqlplus ${SCHEMA}/${PASSWORD} < ${SQLFILE} | grep "MAXID=" | awk '{print $2}'`
+  rm ${SQLFILE}
+}
+##########################################################################
+
+##### Main routine starts here #####
+
+# Get voyager environment, for vars and for cron
+. `echo $HOME | sed "s/$LOGNAME/voyager/"`/.profile.local
+
+# Enable python3, which is not on by default for voyager user
+source /opt/rh/rh-python38/enable
+
+# Base directory
+DIR=/m1/voyager/ucladb/local/sils_migration
+
+# Put large files in /tmp
+OUT_DIR=/tmp/vanguard
+if [ ! -d ${OUT_DIR} ]; then
+  mkdir ${OUT_DIR}
+fi
+
+# Only bib records, for multiple databases
+TYPE=bib
+######for DB in ethnodb filmntvdb ucladb; do
+for DB in ethnodb; do
+  # DB-specific directories for extract program and logs
+  DB_DIR=/m1/voyager/${DB}
+
+  # Code for record type required by the extract program
+  case ${TYPE} in
+    bib ) VGERTYPE=B;;
+  esac
+
+  # Set MAXID (largest id in table) with get_max_id function
+  _get_max_id ${DB} ${TYPE}
+  echo -e "\nExtracting up to ${MAXID} ${TYPE} records from ${DB}"
+
+  # Extract up to 100K records at a time
+  # Assume we'll always start at 1, end at MAXID
+  INTERVAL=100000
+  START=1
+  END=`expr ${START} + ${INTERVAL} - 1`
+
+  # Loop to do the actual work
+  while [ ${START} -le ${MAXID} ]; do
+    # Save time extracting records: don't look for records beyond MAXID
+    if [ ${END} -gt ${MAXID} ]; then
+      END=${MAXID}
+    fi
+
+	EXTRACT_FILE=${OUT_DIR}/${DB}_${TYPE}_${START}_${END}.mrc
+	UPDATE_FILE=${OUT_DIR}/`basename ${EXTRACT_FILE} .mrc`.out
+	# Extract program adds to existing files, so remove these just in case they exist
+	rm -f ${EXTRACT_FILE} ${UPDATE_FILE}
+
+	# Extract the records
+	echo -e "\n`date` Extracting ${EXTRACT_FILE} ..."
+	# TODO: Remove echo
+	echo ${DB_DIR}/sbin/Pmarcexport -o${EXTRACT_FILE} -r${VGERTYPE} -mR -t${START}-${END} -q
+
+	# Delete the useless export log; assumes no other exports happening during the same time.
+	LOG=`ls -1rt ${DB_DIR}/rpt/log.exp.* 2>/dev/null | tail -1`
+	# TODO: Remove echo
+	if [ ${LOG} ]; then
+      echo rm ${LOG}
+	fi
+
+	# Process the records via python program
+	# TODO: Remove echo
+	echo python3 ${DIR}/vanguard.py ${EXTRACT_FILE} ${UPDATE_FILE}
+
+	# Load the updated records back into Voyager, using the GDC bib import profile
+	# TODO: Remove echo
+	echo ${VGER_SCRIPT}/vger_bulkimport_file_NOKEY ${UPDATE_FILE} ${DB} GDC_B_AU
+
+	# Clean up
+	# TODO: Remove echo
+	echo rm ${EXTRACT_FILE} ${UPDATE_FILE}
+
+	# Prepare for next loop iteration
+	START=`expr ${START} + ${INTERVAL}`
+	END=`expr ${END} + ${INTERVAL}`
+  done # Main loop
+done # DB
+
+

--- a/sils_update_bibs.sh
+++ b/sils_update_bibs.sh
@@ -24,6 +24,12 @@ _get_max_id() {
 # Get voyager environment, for vars and for cron
 . `echo $HOME | sed "s/$LOGNAME/voyager/"`/.profile.local
 
+# Is it safe?
+if [ `hostname` != "t-w-voyager01" ]; then
+  echo "ERROR: This can only run on the test server - exiting"
+  exit 1
+fi
+
 # Enable python3, which is not on by default for voyager user
 source /opt/rh/rh-python38/enable
 


### PR DESCRIPTION
This adds `sils_update_bibs.sh`, a shell script which will extract bib records, call the processing python program, and import the updated records back into Voyager, for all 3 databases.

It also renames `vanguard.py` to `process_vanguard_bibs.py`, as this program will only be used for bib records.

Finally, since the shell script uses full paths like `/tmp/vanguard/ethnodb_bib_1_13647.mrc`, this changes `get_dbcode()` to extract the base filename from the path, as that's the part which contains the database name.

The shell script has several steps disabled via `echo` commands, since I don't want to be updating Voyager while developing/testing this; those will be removed when ready.  It also runs now only with ethnodb for easier testing, but I've tested with all databases enabled.

@aprigge please review.