### PR TITLE
SILSLA-17/Modify Suppressed Bib records

### DIFF
--- a/process_vanguard_bibs.py
+++ b/process_vanguard_bibs.py
@@ -158,8 +158,8 @@ for record in reader:
     do_SILSLA_15_bib(record, dbcode)
     if dbcode == "filmntvdb":
         move_939_fatadb(record)
-    writer.write(record)
     do_SILSLA_16(record)
+    writer.write(record)
 
 writer.close()
 reader.close()

--- a/process_vanguard_suppressed_bibs.py
+++ b/process_vanguard_suppressed_bibs.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import copy
 from pymarc import Record, Field, MARCReader, MARCWriter

--- a/process_vanguard_suppressed_bibs.py
+++ b/process_vanguard_suppressed_bibs.py
@@ -3,17 +3,13 @@ import sys
 import copy
 from pymarc import Record, Field, MARCReader, MARCWriter
 
-
 #SILSLA-17
 
 def modify_suppressed_bibs(record):
 	"""Replace (OCoLC) with (Suppressed) in 035 $a for suppressed records"""
 	for fld in record.get_fields("035"):
 		if fld["a"] is not None and fld["a"].startswith("(OCoLC)"):
-			print(fld)
-			new_sfld_a = (copy.copy(fld["a"])).replace("(OCoLC)", "(Suppressed)")
-			fld["a"] = new_sfld_a
-			print(record)
+			fld["a"] = (fld["a"]).replace("(OCoLC)", "(Suppressed)")
 
 def do_SILSLA_17(record):
 	modify_suppressed_bibs(record)
@@ -26,7 +22,7 @@ writer = MARCWriter(open(sys.argv[2], "wb"))
 
 for record in reader:
 	do_SILSLA_17(record)
-
+	writer.write(record)
 
 writer.close()
 reader.close()

--- a/process_vanguard_suppressed_bibs.py
+++ b/process_vanguard_suppressed_bibs.py
@@ -6,13 +6,13 @@ from pymarc import Record, Field, MARCReader, MARCWriter
 #SILSLA-17
 
 def modify_suppressed_bibs(record):
-	"""Replace (OCoLC) with (Suppressed) in 035 $a for suppressed records"""
-	for fld in record.get_fields("035"):
-		if fld["a"] is not None and fld["a"].startswith("(OCoLC)"):
-			fld["a"] = (fld["a"]).replace("(OCoLC)", "(Suppressed)")
+    """Replace (OCoLC) with (Suppressed) in 035 $a for suppressed records"""
+    for fld in record.get_fields("035"):
+        if fld["a"] is not None and fld["a"].startswith("(OCoLC)"):
+            fld["a"] = (fld["a"]).replace("(OCoLC)", "(Suppressed)")
 
 def do_SILSLA_17(record):
-	modify_suppressed_bibs(record)
+    modify_suppressed_bibs(record)
 
 if len(sys.argv) != 3:
     raise ValueError(f"Usage: {sys.argv[0]} in_file out_file")
@@ -21,8 +21,8 @@ reader = MARCReader(open(sys.argv[1], "rb"))
 writer = MARCWriter(open(sys.argv[2], "wb"))
 
 for record in reader:
-	do_SILSLA_17(record)
-	writer.write(record)
+    do_SILSLA_17(record)
+    writer.write(record)
 
 writer.close()
 reader.close()

--- a/process_vanguard_suppressed_bibs.py
+++ b/process_vanguard_suppressed_bibs.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import copy
+from pymarc import Record, Field, MARCReader, MARCWriter
+
+
+#SILSLA-17
+
+def modify_suppressed_bibs(record):
+	"""Replace (OCoLC) with (Suppressed) in 035 $a for suppressed records"""
+	for fld in record.get_fields("035"):
+		if fld["a"] is not None and fld["a"].startswith("(OCoLC)"):
+			print(fld)
+			new_sfld_a = (copy.copy(fld["a"])).replace("(OCoLC)", "(Suppressed)")
+			fld["a"] = new_sfld_a
+			print(record)
+
+def do_SILSLA_17(record):
+	modify_suppressed_bibs(record)
+
+if len(sys.argv) != 3:
+    raise ValueError(f"Usage: {sys.argv[0]} in_file out_file")
+
+reader = MARCReader(open(sys.argv[1], "rb"))
+writer = MARCWriter(open(sys.argv[2], "wb"))
+
+for record in reader:
+	do_SILSLA_17(record)
+
+
+writer.close()
+reader.close()


### PR DESCRIPTION
I'm assuming this separate program will only get suppressed bib records.

-Adds a function to modify 035 $a if it starts with  `(OCoLC)`
-Fixes ordering error in `process_vanguard_bibs.py`