### PR TITLE
SILSLA-20: Add controller script for SCP records

### DIFF
--- a/SQL/scp_silsla18_case1.sql
+++ b/SQL/scp_silsla18_case1.sql
@@ -1,5 +1,8 @@
+set linesize 10;
+
 -- Spec #1: Pure CDL bibs, no print holdings, no UCLA 856 fields, WITHOUT PO
 -- DELETE bibs and holdings for Vanguard.
+
 with bibs as (
   select distinct
     record_id as bib_id

--- a/SQL/scp_silsla18_case2.sql
+++ b/SQL/scp_silsla18_case2.sql
@@ -1,5 +1,8 @@
+set linesize 10;
+
 -- Spec #2: Pure CDL bibs, no print holdings, no UCLA 856 fields, WITH PO
 -- DELETE bibs and holdings for Vanguard.
+
 with bibs as (
   select distinct
     record_id as bib_id

--- a/SQL/scp_silsla18_case3.sql
+++ b/SQL/scp_silsla18_case3.sql
@@ -1,5 +1,8 @@
+set linesize 10;
+
 -- Spec #3: Hybrid CDL/UCLA bibs WITHOUT open CDL PO
 -- UPDATE bibs, with CDL 856 deletion
+
 with bibs as (
   select distinct
     record_id as bib_id

--- a/SQL/scp_silsla18_case4.sql
+++ b/SQL/scp_silsla18_case4.sql
@@ -1,5 +1,8 @@
+set linesize 10;
+
 -- Spec #4: Hybrid CDL/UCLA bibs WITH open CDL PO
 -- UPDATE bibs, with CDL 856 modification
+
 with bibs as (
   select distinct
     record_id as bib_id

--- a/SQL/scp_silsla18_case5.sql
+++ b/SQL/scp_silsla18_case5.sql
@@ -1,5 +1,8 @@
+set linesize 10;
+
 -- Spec #5: Pure CDL bibs, HAS print holdings, no UCLA 856 fields
 -- UPDATE bibs, with CDL 856 deletion, AND delete internet holdings
+
 with bibs as (
   select distinct
     record_id as bib_id

--- a/process_vanguard_scp_bibs.py
+++ b/process_vanguard_scp_bibs.py
@@ -76,7 +76,7 @@ for record in reader:
 		# Case 4 from specs
 		modify_856(record)
 	else:
-		# Cases 3 and 5 from sepcs
+		# Cases 3 and 5 from specs
 		delete_856(record)
 
 	# Done making changes, save the changed record to file

--- a/sils_update_bibs.sh
+++ b/sils_update_bibs.sh
@@ -52,6 +52,7 @@ for DB in ethnodb; do
   # Code for record type required by the extract program
   case ${TYPE} in
     bib ) VGERTYPE=B;;
+    *   ) echo "ERROR: Invalid type ${TYPE} - exiting"; exit 1;;
   esac
 
   # Set MAXID (largest id in table) with get_max_id function

--- a/sils_update_scp.sh
+++ b/sils_update_scp.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+# Extracts SCP records from the UCLA db only,
+# calls appropriate cleanup programs for each file,
+# and loads updated records back into the relevant database.
+# SILSLA-20
+
+##### Main routine starts here #####
+
+# Get voyager environment, for vars and for cron
+. `echo $HOME | sed "s/$LOGNAME/voyager/"`/.profile.local
+
+# Is it safe?
+if [ `hostname` != "t-w-voyager01" ]; then
+  echo "ERROR: This can only run on the test server - exiting"
+  exit 1
+fi
+
+# Enable python3, which is not on by default for voyager user
+source /opt/rh/rh-python38/enable
+
+# Base directory
+DIR=/m1/voyager/ucladb/local/sils_migration
+cd ${DIR}
+
+# Put large files in /tmp
+OUT_DIR=/tmp/vanguard
+if [ ! -d ${OUT_DIR} ]; then
+  mkdir ${OUT_DIR}
+fi
+
+# Only bib records, for multiple databases
+TYPE=bib
+DB=ucladb
+# DB-specific directories for extract program and logs
+DB_DIR=/m1/voyager/${DB}
+
+# Code for record type required by the extract program
+case ${TYPE} in
+  bib ) VGERTYPE=B;;
+  *   ) echo "ERROR: Invalid type ${TYPE} - exiting"; exit 1;;
+esac
+
+# Run several SQL files, each covering a different scenario with different specs.
+# Each spec needs separate/different handling.
+for SPEC in 1 2 3 4 5; do
+  SQL_FILE=SQL/scp_silsla18_case${SPEC}.sql
+  # Run the query to get the record ids; data will be in SQL_FILE.out in the same directory as SQL_FILE.
+  ${VGER_SCRIPT}/vger_sqlplus_run ucla_preaddb ${SQL_FILE}
+  ID_FILE=${OUT_DIR}/`basename ${SQL_FILE}.out`
+  mv ${SQL_FILE}.out ${ID_FILE}
+  wc -l ${ID_FILE}
+
+  # Handle each list of ids differently.
+  # Some lists may not be handled within this script (e.g., load into GDC and run a job there).
+  case ${SPEC} in
+    1 ) echo "##### Load ${ID_FILE} into GDC and run a DELETE ALL job #####"
+        ;;
+    2 ) echo "##### Load ${ID_FILE} into GDC and run a SUPPRESS ALL job #####"
+        ;;
+3|4|5 ) # Handle these cases the same, except for HAS_PO parameter
+        if [ ${SPEC} -eq 4 ]; then
+          HAS_PO=Y
+        else
+          HAS_PO=N
+        fi
+
+	    EXTRACT_FILE=${OUT_DIR}/scp_case${SPEC}_${DB}_${TYPE}.mrc
+    	UPDATE_FILE=${OUT_DIR}/`basename ${EXTRACT_FILE} .mrc`.out
+	    # Extract program adds to existing files, so remove these just in case they exist
+	    rm -f ${EXTRACT_FILE} ${UPDATE_FILE}
+
+	    # Extract the records
+	    echo -e "\n`date` Extracting ${EXTRACT_FILE} ..."
+	    ${DB_DIR}/sbin/Pmarcexport -o${EXTRACT_FILE} -r${VGERTYPE} -mM -t${ID_FILE} -q
+
+	    # Delete the useless export log; assumes no other exports happening during the same time.
+	    LOG=`ls -1rt ${DB_DIR}/rpt/log.exp.* 2>/dev/null | tail -1`
+	    if [ ${LOG} ]; then
+          rm ${LOG}
+	    fi
+
+	    # Process the records via python program
+	    # TODO: Remove echo
+	    echo python3 ${DIR}/scp_bib_update.py ${EXTRACT_FILE} ${UPDATE_FILE} ${HAS_PO}
+
+	    # Load the updated records back into Voyager, using the GDC bib import profile
+	    # TODO: Remove echo
+	    echo ${VGER_SCRIPT}/vger_bulkimport_file_NOKEY ${UPDATE_FILE} ${DB} GDC_B_AU
+
+	    # Clean up
+	    # TODO: Remove echo
+	    echo rm ${EXTRACT_FILE} ${UPDATE_FILE}
+        ;;
+  esac
+done
+
+exit 1
+
+
+
+

--- a/sils_update_scp.sh
+++ b/sils_update_scp.sh
@@ -95,8 +95,3 @@ for SPEC in 1 2 3 4 5; do
   esac
 done
 
-exit 1
-
-
-
-


### PR DESCRIPTION
This PR mainly adds a controller script for processing SCP records, `sils_update_scp.sh`
To support/improve that, it also:
* Adds sqlplus linesize to SQL, so the lists of ids are correctly formatted
* Renames `scp_bib_update.py` to `process_vanguard_scp_bibs.py` for consistency (and fixes a minor typo)
* Adds error checking to `sils_update_bibs.sh` for consistency with other scripts

@aprigge Please review if you're still around; no worries if not, I'll self-approve as I'll be using these this weekend to test how long things take.  Thanks --Andy