### PR TITLE
Fixes get_dbcode() throwing error incorrectly

### DIFF
--- a/process_vanguard_bibs.py
+++ b/process_vanguard_bibs.py
@@ -68,13 +68,14 @@ def delete_various_9xx(record):
 def get_dbcode(filename):
     """Helper function to get dbcode from filename"""
     basename = os.path.basename(filename)
-    for dbcode in ["filmntvdb", "ucladb", "ethnodb"]:
-        if basename.startswith(dbcode):
-            return dbcode
-        else:
-            raise ValueError(
-                f"Usage: {filename} filename must include originating dbcode"
-            )
+    # Assumes caller will name files like ethnodb_bib_..., ucladb_mfhd_... etc.
+    dbcode = basename.split("_")[0]
+    if dbcode in ["filmntvdb", "ucladb", "ethnodb"]:
+        return dbcode
+    else:
+        raise ValueError(
+            f"Usage: {filename} filename must include originating dbcode"
+        )
 
 def copy_001(record, dbcode):
     """Copy 001 field, append dbcode, and add as $a to 996"""


### PR DESCRIPTION
This fixes `get_dbcode()`, which would throw an error incorrectly if the base filename did not start with the first value in the list.
The original code:
```
    for dbcode in ["filmntvdb", "ucladb", "ethnodb"]:
        if basename.startswith(dbcode):
            return dbcode
        else:
            raise ValueError(
                f"Usage: {filename} filename must include originating dbcode"
            )
```
So if `basename` starts with `ucladb` or `ethnodb`, the test in the first `for` iteration is false, and an error is raised immediately, without the chance to test the other values.

There are several ways to fix this, but since we are trusting the calling script to pass filenames with a certain structure, this fix just splits the base filename on underscore, takes the first value, and sees if it's in the allowed list.
